### PR TITLE
Use the same classIndex approach as from the getStyleDescriptionForLayer:inClass:

### DIFF
--- a/mapbox-gl-cocoa/MGLMapView.mm
+++ b/mapbox-gl-cocoa/MGLMapView.mm
@@ -1056,7 +1056,7 @@ LLMRView *llmrView = nullptr;
 
     NSMutableDictionary *style = [[self getRawStyle] deepMutableCopy];
 
-    NSUInteger classIndex = [[self getAllStyleClasses] indexOfObject:className];
+    NSUInteger classIndex = [[style valueForKeyPath:@"classes.name"] indexOfObject:className];
 
     style[@"classes"][classIndex][@"layers"][layerName] = convertedStyle;
 


### PR DESCRIPTION
I keep running into a crash trying to set the style description of a layer because this line is returning NSNotFound.

I thought this would be a little better than an issue but feel free to close without merging and fix it yourself. This was meant just to point out the line since I can't compile the lib or test (couldn't figure out the dependencies, are they all public?)
