### PR TITLE
Add missing log backend init

### DIFF
--- a/app/MBXViewController.mm
+++ b/app/MBXViewController.mm
@@ -28,6 +28,7 @@ mbgl::Settings_NSUserDefaults *settings = nullptr;
 
     if (self)
     {
+        mbgl::Log::Set<mbgl::NSLogBackend>();
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(saveState:) name:UIApplicationDidEnterBackgroundNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(restoreState:) name:UIApplicationWillEnterForegroundNotification object:nil];
     }


### PR DESCRIPTION
The log backend is init at MGLMapView. But at MBXViewController there is no log backend when checking the existence of an access token.
Alternatively, is it preferred to use NSLog here instead?
