### PR TITLE
add showLogoBug and hide attribution fix #33

### DIFF
--- a/mapbox-gl-cocoa/MGLMapView.h
+++ b/mapbox-gl-cocoa/MGLMapView.h
@@ -71,6 +71,9 @@
 *   The default value of this property is `YES`. */
 @property(nonatomic, getter=isRotateEnabled) BOOL rotateEnabled;
 
+/** A Boolean value indicating whether to show a small logo in the corner of the map view. Defaults to `YES`. */
+@property (nonatomic, assign) BOOL showLogoBug;
+
 #pragma mark - Accessing the Delegate
 
 /** @name Accessing the Delegate */

--- a/mapbox-gl-cocoa/MGLMapView.h
+++ b/mapbox-gl-cocoa/MGLMapView.h
@@ -74,6 +74,15 @@
 /** A Boolean value indicating whether to show a small logo in the corner of the map view. Defaults to `YES`. */
 @property (nonatomic, assign) BOOL showLogoBug;
 
+/** @name Attributing Map Data */
+
+/** Whether to hide map data attribution for the map view.
+*
+*   If this is set to NO, a small disclosure button will be added to the lower-right of the map view, allowing the user to tap it to display a modal view showing map data attribution info. The modal presentation uses a page curl animation to reveal the attribution info under the map view.
+*
+*   The default value is NO, meaning that attribution info will be shown. Please ensure that the terms & conditions of any map data used in your application are satisfied before setting this value to YES. */
+@property (nonatomic, assign) BOOL hideAttribution;
+
 #pragma mark - Accessing the Delegate
 
 /** @name Accessing the Delegate */

--- a/mapbox-gl-cocoa/MGLMapView.mm
+++ b/mapbox-gl-cocoa/MGLMapView.mm
@@ -1456,4 +1456,13 @@ class MBGLView : public mbgl::View
     _showLogoBug = showLogoBug;
 }
 
+- (void)setHideAttribution:(BOOL)flag
+{
+    if (_hideAttribution == flag)
+        return;
+    
+    self.attributionButton.hidden = flag;
+    _hideAttribution = flag;
+}
+
 @end

--- a/mapbox-gl-cocoa/MGLMapView.mm
+++ b/mapbox-gl-cocoa/MGLMapView.mm
@@ -178,13 +178,7 @@ MBGLView *mbglView = nullptr;
     mbglMap = new mbgl::Map(*mbglView);
     mbglMap->resize(self.bounds.size.width, self.bounds.size.height, _glView.contentScaleFactor, _glView.drawableWidth, _glView.drawableHeight);
 
-    // setup logo bug
-    //
-    _logoBug = [[UIImageView alloc] initWithImage:[MGLMapView resourceImageNamed:@"mapbox.png"]];
-    _logoBug.accessibilityLabel = @"Mapbox logo";
-    _logoBug.frame = CGRectMake(8, self.bounds.size.height - _logoBug.bounds.size.height - 4, _logoBug.bounds.size.width, _logoBug.bounds.size.height);
-    _logoBug.translatesAutoresizingMaskIntoConstraints = NO;
-    [self addSubview:_logoBug];
+    self.showLogoBug = YES;
 
     // setup attribution
     //
@@ -370,16 +364,19 @@ MBGLView *mbglView = nullptr;
 
     // logo bug
     //
-    [constraintParentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:[NSString stringWithFormat:@"V:[logoBug]-bottomSpacing-%@", bottomGuideFormatString]
-                                                                                 options:0
-                                                                                 metrics:@{ @"bottomSpacing"     : @(4) }
-                                                                                   views:@{ @"logoBug"           : self.logoBug,
-                                                                                            @"bottomLayoutGuide" : bottomGuideViewsObject }]];
-
-    [constraintParentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-leftSpacing-[logoBug]"
-                                                                                 options:0
-                                                                                 metrics:@{ @"leftSpacing"       : @(8) }
-                                                                                   views:@{ @"logoBug"           : self.logoBug }]];
+    if (self.logoBug)
+    {
+        [constraintParentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:[NSString stringWithFormat:@"V:[logoBug]-bottomSpacing-%@", bottomGuideFormatString]
+                                                                                     options:0
+                                                                                     metrics:@{ @"bottomSpacing"     : @(4) }
+                                                                                       views:@{ @"logoBug"           : self.logoBug,
+                                                                                                @"bottomLayoutGuide" : bottomGuideViewsObject }]];
+        
+        [constraintParentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-leftSpacing-[logoBug]"
+                                                                                     options:0
+                                                                                     metrics:@{ @"leftSpacing"       : @(8) }
+                                                                                       views:@{ @"logoBug"           : self.logoBug }]];
+    }
 
     // attribution button
     //
@@ -1439,5 +1436,24 @@ class MBGLView : public mbgl::View
     private:
         MGLMapView *nativeView = nullptr;
 };
+
+- (void)setShowLogoBug:(BOOL)showLogoBug
+{
+    if (showLogoBug && ! _logoBug)
+    {
+        _logoBug = [[UIImageView alloc] initWithImage:[MGLMapView resourceImageNamed:@"mapbox.png"]];
+        _logoBug.accessibilityLabel = @"Mapbox logo";
+        _logoBug.frame = CGRectMake(8, self.bounds.size.height - _logoBug.bounds.size.height - 4, _logoBug.bounds.size.width, _logoBug.bounds.size.height);
+        _logoBug.translatesAutoresizingMaskIntoConstraints = NO;
+        [self addSubview:_logoBug];
+    }
+    else if ( ! showLogoBug && _logoBug)
+    {
+        [_logoBug removeFromSuperview];
+        _logoBug = nil;
+    }
+    
+    _showLogoBug = showLogoBug;
+}
 
 @end


### PR DESCRIPTION
show logo bug was ported from mapbox-ios-sdk.
For hide attribution, it keeps the web link as discussed in #22
Should I add KIF tests for this?

Related: #22 #24
